### PR TITLE
Dockerfile for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.4.3
+MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
+
+RUN mkdir -p /usr/src/app /usr/control-repo
+
+COPY . /usr/src/app
+RUN pip install /usr/src/app
+
+VOLUME /usr/control-repo
+WORKDIR /usr/control-repo
+
+CMD ["deconst-preparer-sphinx"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ The *deconst Sphinx preparer* builds [Sphinx documentation](http://sphinx-doc.or
 
 It's intended to be used within a CI system to present content to the rest of build pipeline.
 
+## Running Locally
+
+To run the asset preparer locally, you'll need to install:
+
+ * [Docker](https://docs.docker.com/installation/#installation) for your platform. Choose the boot2docker option for Mac OS X or Windows.
+
+Once you have Docker set up, export any desired configuration variables, run `deconst-preparer-sphinx.sh` with the path of a control repository clone to prepare the assets found there.
+
+```bash
+export CONTENT_STORE_URL=http://my-content-store.com:9000/
+export CONTENT_ID_BASE=https://github.com/myorg/myrepo
+
+./deconst-preparer-sphinx.sh /path/to/control-repo
+```
+
+### Configuration
+
+The following values must be present in the build environment to submit assets:
+
+ * `CONTENT_STORE_URL` must be the base URL of the publicly available content store service. The prepare script defaults this to one consistent with our docker-compose setups.
+ * `CONTENT_ID_BASE` must be set to a prefix that's unique among the content repositories associated with the target deconst instance. Our convention is to use the base URL of the GitHub repository.
+ * `TRAVIS_PULL_REQUEST` must be set to `"false"`. Travis automatically sets this value for your build environment on the primary branch of your repository.
+
 ## reStructuredText integration
 
 Sphinx doesn't natively have the concept of a per-page layout. To tell Deconst which layout to use for a specific page, add the following field to a field list that's the *first thing* within a page, along with any other [per-page metadata](http://sphinx-doc.org/markup/misc.html#file-wide-metadata) that's present:

--- a/deconst-preparer-sphinx.sh
+++ b/deconst-preparer-sphinx.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SUDO=sudo
+
+which boot2docker >/dev/null 2>&1 && {
+  SUDO=
+  CONTENT_STORE_URL=${CONTENT_STORE_URL:-http://$(boot2docker ip):9000/}
+}
+
+CONTENT_STORE_URL=${CONTENT_STORE_URL:-http://localhost:9000/}
+WORKDIR=${1:-$(pwd)}
+
+[ -z "${CONTENT_ID_BASE}" ] && {
+  cat <<EOM 1>&2
+Please specify a content ID base:
+
+  export CONTENT_ID_BASE=https://github.com/myname/myrepo
+
+Our convention is to use the base URL of your GitHub repo.
+EOM
+  exit 1
+}
+
+${SUDO} docker run \
+  --rm=true \
+  -e CONTENT_STORE_URL=${CONTENT_STORE_URL} \
+  -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
+  -e TRAVIS_PULL_REQUEST="false" \
+  -v ${WORKDIR}:/usr/control-repo \
+  quay.io/deconst/preparer-sphinx


### PR DESCRIPTION
Provide a Docker image and wrapper script to easily invoke the preparer locally.

The next part of deconst/deconst-docs#49.