### PR TITLE
Override the page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following values must be present in the build environment to submit assets:
 
 ## reStructuredText integration
 
+### Layout
+
 Sphinx doesn't natively have the concept of a per-page layout. To tell Deconst which layout to use for a specific page, add the following field to a field list that's the *first thing* within a page, along with any other [per-page metadata](http://sphinx-doc.org/markup/misc.html#file-wide-metadata) that's present:
 
 ```rst
@@ -48,3 +50,13 @@ deconst_default_layout = "default-layout-key"
 ```
 
 Finally, the preparer will fall back to `"default"` if no other key is specified.
+
+### Title
+
+Similary, you can override the `"title"` Sphinx generates for any page by specifying a `deconsttitle` per-page attribute:
+
+```rst
+:deconsttitle: The real title
+```
+
+This is especially important for your `index.rst` file, which by default generates a title of "&lt; no title &gt;".

--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -44,7 +44,7 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
 
         envelope = {
             "body": context["body"],
-            "title": context["title"],
+            "title": context["deconst_title"],
             "layout_key": context["deconst_layout_key"]
         }
 
@@ -59,6 +59,7 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
         meta = self.env.metadata[pagename]
         ctx["deconst_layout_key"] = meta.get(
             "deconstlayout", self.config.deconst_default_layout)
+        ctx["deconst_title"] = meta.get("deconsttitle", ctx["title"])
 
         super().handle_page(pagename, ctx, *args, **kwargs)
 


### PR DESCRIPTION
Allow per-page metadata to override the page title that Sphinx generates.