### PR TITLE
Include the table of contents in the envelope.

### DIFF
--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -62,6 +62,9 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
                 "title": p["title"]
             }
 
+        if context["display_toc"]:
+            envelope["toc"] = context["toc"]
+
         super().dump_context(envelope, filename)
 
     def handle_page(self, pagename, ctx, *args, **kwargs):


### PR DESCRIPTION
If Sphinx would emit a table of contents for the current page, include the HTML for one in the envelope:

```json
{
  "next": {
    "title": "Data services",
    "url": "../data_services/"
  },
  "toc": "<ul>\n<li><a class=\"reference internal\" href=\"#\">Storage and content delivery services</a><ul>\n<li><a class=\"reference internal\" href=\"#cloud-block-storage-at-a-glance\">Cloud Block Storage at a glance</a></li>\n<li><a class=\"reference internal\" href=\"#cloud-backup-at-a-glance\">Cloud Backup at a glance</a></li>\n<li><a class=\"reference internal\" href=\"#cloud-cdn-at-a-glance\">Cloud CDN at a glance</a></li>\n<li><a class=\"reference internal\" href=\"#cloud-files-at-a-glance\">Cloud Files at a glance</a></li>\n</ul>\n</li>\n</ul>\n",
  "layout_key": "default",
  "body": ".. snip ..",
  "previous": {
    "title": "Network services",
    "url": "../network_services/"
  },
  "title": "Storage and content delivery services"
}

```