### PR TITLE
Keep configuration consistent with the Jekyll preparer.

### DIFF
--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -15,8 +15,8 @@ def main():
 
     config = Configuration(os.environ)
 
-    if os.path.exists(".deconst.json"):
-        with open(".deconst.json", "r") as cf:
+    if os.path.exists("_deconst.json"):
+        with open("_deconst.json", "r") as cf:
             config.apply_file(cf)
 
     # Lock source and destination to the same paths as the Makefile.

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -36,7 +36,7 @@ class Configuration:
         doc = json.load(f)
 
         for setting, value in doc.items():
-            if setting == "content-id-base":
+            if setting == "contentIDBase":
                 if not self.content_id_base:
                     self.content_id_base = value
                 elif self.content_id_base != value:


### PR DESCRIPTION
The Jekyll preparer uses an underscore-prefixed `_deconst.json` file instead of a dotfile, because Jekyll copies all files verbatim unless their names start with an underscore. I'm making it consistent here even though Sphinx doesn't care about the filename, because it probably shouldn't be a hidden file, anyway.

I'm also updating the spec to accept the same camelCased setting.