### PR TITLE
Read _deconst.json in the builder too.

### DIFF
--- a/deconstrst/builder.py
+++ b/deconstrst/builder.py
@@ -27,6 +27,11 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
         JSONHTMLBuilder.init(self)
 
         self.deconst_config = Configuration(os.environ)
+
+        if os.path.exists("_deconst.json"):
+            with open("_deconst.json", "r") as cf:
+                self.deconst_config.apply_file(cf)
+
         self.should_submit = not self.deconst_config.skip_submit_reasons()
 
     def finish(self):


### PR DESCRIPTION
The configuration was being read twice, once in `__init__.py` and once in `builder.py`, but I was only applying the `_deconst.json` overrides in `__init__.py`.

I'm not a huge fan of the duplication here, but this will do for now.