### PR TITLE
Adding SingleJSON builder that acts like singlehtml, but for deconst

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ export CONTENT_ID_BASE=https://github.com/myorg/myrepo
 
 ### Configuration
 
+By default, the preparer will use the `deconst-serial` builder, which will generate a separate HTML file for every ReST file in your repository. This behavior is similar to running `make html`. If you would rather generate a single HTML file with the contents of your entire repo (à la `make singlehtml`), you must add the following line to your `conf.py` file:
+
+```python
+builder = 'deconst-single'
+```
+
 The following values must be present in the build environment to submit assets:
 
  * `CONTENT_STORE_URL` must be the base URL of the publicly available content store service. The prepare script defaults this to one consistent with our docker-compose setups.

--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from deconstrst.deconstrst import build, submit
+from deconstrst.deconstrst import build, submit, get_conf_builder
 from deconstrst.config import Configuration
 
 __author__ = 'Ash Wilson'
@@ -11,7 +11,10 @@ __email__ = 'ash.wilson@rackspace.com'
 __version__ = '0.1.0'
 
 
-def main():
+def main(directory=False):
+
+    if directory:
+        os.chdir(directory)
 
     config = Configuration(os.environ)
 
@@ -20,7 +23,8 @@ def main():
             config.apply_file(cf)
 
     # Lock source and destination to the same paths as the Makefile.
-    srcdir, destdir = '.', '_build/deconst'
+    srcdir = '.'
+    destdir = os.path.join('_build', get_conf_builder())
 
     status = build(srcdir, destdir)
     if status != 0:

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -15,7 +15,7 @@ from deconstrst.config import Configuration
 Config.config_values["deconst_default_layout"] = ("default", "html")
 
 
-class DeconstJSONBuilder(JSONHTMLBuilder):
+class DeconstSerialJSONBuilder(JSONHTMLBuilder):
     """
     Custom Sphinx builder that generates Deconst-compatible JSON documents.
     """
@@ -43,6 +43,7 @@ class DeconstJSONBuilder(JSONHTMLBuilder):
         """
 
     def dump_context(self, context, filename):
+
         """
         Override the default serialization code to save a derived metadata
         envelope, instead.

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -80,7 +80,7 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         outfile = os.path.join(self.outdir, self.config.master_doc + '.json')
 
         with open(outfile, 'w') as dumpfile:
-            json.dump({"envelope": envelope}, dumpfile)
+            json.dump(envelope, dumpfile)
 
     def finish(self):
         """

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -16,7 +16,6 @@ from sphinx.util.console import bold, darkgreen, brown
 from sphinx.writers.html import HTMLWriter
 from sphinx.config import Config
 from deconstrst.config import Configuration
-from pprint import pprint
 
 # Tell Sphinx about the deconst_default_layout key.
 Config.config_values["deconst_default_layout"] = ("default", "html")

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+import os
+import mimetypes
+import json
+from os import path
+
+import requests
+from docutils import nodes
+from docutils.io import DocTreeInput, StringOutput
+from sphinx.builders.html import SingleFileHTMLBuilder
+from sphinx.builders.html import JSONHTMLBuilder
+from sphinx.util import jsonimpl
+from sphinx.util.osutil import os_path, relative_uri
+from sphinx.util.console import bold, darkgreen, brown
+from sphinx.writers.html import HTMLWriter
+from sphinx.config import Config
+from deconstrst.config import Configuration
+from pprint import pprint
+
+# Tell Sphinx about the deconst_default_layout key.
+Config.config_values["deconst_default_layout"] = ("default", "html")
+
+
+class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
+    """
+    Custom Sphinx builder that generates Deconst-compatible JSON documents.
+    """
+
+    name = 'deconst-single'
+
+    def init(self):
+        SingleFileHTMLBuilder.init(self)
+
+        self.deconst_config = Configuration(os.environ)
+
+        if os.path.exists("_deconst.json"):
+            with open("_deconst.json", "r") as cf:
+                self.deconst_config.apply_file(cf)
+
+        self.should_submit = not self.deconst_config.skip_submit_reasons()
+
+    def write(self, *ignored):
+        docnames = self.env.all_docs
+
+        self.info(bold('preparing documents... '), nonl=True)
+        self.prepare_writing(docnames)
+        self.info('done')
+
+        self.info(bold('assembling single document... '), nonl=True)
+        doctree = self.assemble_doctree()
+        doctree.settings = self.docsettings
+
+        self.env.toc_secnumbers = self.assemble_toc_secnumbers()
+        self.secnumbers = self.env.toc_secnumbers.get(self.config.master_doc, {})
+        self.fignumbers = self.env.toc_fignumbers.get(self.config.master_doc, {})
+        self.imgpath = relative_uri(self.get_target_uri(self.config.master_doc), '_images')
+        self.dlpath = relative_uri(self.get_target_uri(self.config.master_doc), '_downloads')
+        self.current_docname = self.config.master_doc
+
+        if self.should_submit:
+            self.post_process_images(doctree)
+
+        meta = self.env.metadata.get(self.config.master_doc)
+
+        title = self.env.longtitles.get(self.config.master_doc)
+        toc = self.env.get_toctree_for(self.config.master_doc, self, False)
+
+        rendered_title = self.render_partial(title)['title']
+        rendered_body = self.render_partial(doctree)['fragment']
+        rendered_toc = self.render_partial(toc)['fragment']
+
+        envelope = {
+            "title": meta.get('deconsttitle', rendered_title),
+            "body": rendered_body,
+            "toc": rendered_toc,
+            "layout_key": meta.get('deconstlayout', self.config.deconst_default_layout),
+            "meta": dict(meta)
+        }
+
+        outfile = os.path.join(self.outdir, self.config.master_doc + '.json')
+
+        with open(outfile, 'w') as dumpfile:
+            json.dump({"envelope": envelope}, dumpfile)
+
+    def finish(self):
+        """
+        Nothing to see here
+        """
+
+
+    def post_process_images(self, doctree):
+        """
+        Publish images to the content store. Modify the image reference with
+        the
+        """
+
+        JSONHTMLBuilder.post_process_images(self, doctree)
+
+        if self.should_submit:
+            for node in doctree.traverse(nodes.image):
+                node['uri'] = self._publish_entry(node['uri'])
+
+
+    def _publish_entry(self, srcfile):
+        (content_type, _) = mimetypes.guess_type(srcfile)
+
+        auth = 'deconst apikey="{}"'.format(
+            self.deconst_config.content_store_apikey)
+        headers = {"Authorization": auth}
+
+        url = self.deconst_config.content_store_url + "assets"
+        basename = path.basename(srcfile)
+        if content_type:
+            payload = (basename, open(srcfile, 'rb'), content_type)
+        else:
+            payload = open(srcfile, 'rb')
+        files = {basename: payload}
+
+        response = requests.post(url, files=files, headers=headers)
+        response.raise_for_status()
+        return response.json()[basename]

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -94,7 +94,7 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         the
         """
 
-        JSONHTMLBuilder.post_process_images(self, doctree)
+        SingleFileHTMLBuilder.post_process_images(self, doctree)
 
         if self.should_submit:
             for node in doctree.traverse(nodes.image):

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -39,6 +39,24 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
 
         self.should_submit = not self.deconst_config.skip_submit_reasons()
 
+    def fix_refuris(self, tree):
+        """
+        The parent implementation of this includes the base file name, which
+        breaks if we serve with a trailing slash. We just want what's between
+        the last "#" and the end of the string
+        """
+
+        # fix refuris with double anchor
+        for refnode in tree.traverse(nodes.reference):
+            if 'refuri' not in refnode:
+                continue
+            refuri = refnode['refuri']
+            hashindex = refuri.rfind('#')
+            if hashindex < 0:
+                continue
+
+            refnode['refuri'] = refuri[hashindex:]
+
     def write(self, *ignored):
         docnames = self.env.all_docs
 
@@ -64,6 +82,8 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
 
         title = self.env.longtitles.get(self.config.master_doc)
         toc = self.env.get_toctree_for(self.config.master_doc, self, False)
+
+        self.fix_refuris(toc)
 
         rendered_title = self.render_partial(title)['title']
         rendered_body = self.render_partial(doctree)['fragment']

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -44,16 +44,13 @@ def get_conf_builder():
 
     try:
         code = compile(conf_data, 'conf.py', 'exec')
+        exec(code)
     except SyntaxError:
-        raise
+        """
+        We'll just pretend nothing happend and use the default builder
+        """
 
-    exec(code)
-    local_vars = locals()
-
-    try:
-        return local_vars['builder']
-    except KeyError:
-        return DEFAULT_BUILDER
+    return locals().get('builder', DEFAULT_BUILDER)
 
 def submit(destdir, content_store_url, content_store_apikey, content_id_base):
     """

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -35,12 +35,8 @@ def build(srcdir, destdir):
     return app.statuscode
 
 def get_conf_builder():
-    conf_file = open('conf.py')
-
-    try:
+    with open('conf.py') as conf_file:
         conf_data = conf_file.read()
-    finally:
-        conf_file.close()
 
     try:
         code = compile(conf_data, 'conf.py', 'exec')


### PR DESCRIPTION
O mighty @smashwilson please tell me what I've done wrong :wink: 

Really, there's a lot of copy/paste from https://github.com/sphinx-doc/sphinx/blob/1.3.1/sphinx/builders/html.py#L894 that could _probably_ be done better by just calling the parent class's method.

There's probably also room at some point to combine the `_publish_entry()` stuff so it can be reused and not just copy/pasted as I've done here.

#### Significant changes:

* Allow preparer to be run against another directory instead of just the current directory. Mostly to scratch my own itch and test easily. `deconstrst.main('/usr/content-repo')`
* Add `DeconstSingleJSONBuilder` that borrows from `SingleFileHTMLBuilder` but builds a JSON envelope with a big, beautiful ToC
* Allow content repos to choose which builder they want (`deconst-single` or `deconst-serial`) and default to `deconst-serial` for backwards compatibility.