### PR TITLE
Include deconstrst.builders in setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ setup(
         'deconstrst',
         'deconstrst.builders'
     ],
-    package_dir={'deconstrst':
-                 'deconstrst'},
     include_package_data=True,
     install_requires=requirements,
     license="Apache 2",

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     url='https://github.com/deconst/preparer-sphinx',
     packages=[
         'deconstrst',
+        'deconstrst.builders'
     ],
     package_dir={'deconstrst':
                  'deconstrst'},


### PR DESCRIPTION
It turns out that Python doesn't include packages in an egg unless it's listed in the `packages` field. This adds the new "builders" package in the list.

Fixes deconst/deconst-docs#161.