### PR TITLE
Change the path of the content repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.4.3
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
 
-RUN mkdir -p /usr/src/app /usr/control-repo
+RUN mkdir -p /usr/src/app /usr/content-repo
 
 COPY . /usr/src/app
 RUN pip install /usr/src/app
 
-VOLUME /usr/control-repo
-WORKDIR /usr/control-repo
+VOLUME /usr/content-repo
+WORKDIR /usr/content-repo
 
 CMD ["deconst-preparer-sphinx"]


### PR DESCRIPTION
Change the path that we use to map the content repository to be consistent with the changed path that the Jekyll preparer uses.

This will break the local Deconst client until I can push another release.