### PR TITLE
be more specific about where conf.py should be found

### DIFF
--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -24,7 +24,7 @@ def main(directory=False):
 
     # Lock source and destination to the same paths as the Makefile.
     srcdir = '.'
-    destdir = os.path.join('_build', get_conf_builder())
+    destdir = os.path.join('_build', get_conf_builder(srcdir))
 
     status = build(srcdir, destdir)
     if status != 0:

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -22,7 +22,7 @@ def build(srcdir, destdir):
     BUILTIN_BUILDERS['deconst-serial'] = DeconstSerialJSONBuilder
     BUILTIN_BUILDERS['deconst-single'] = DeconstSingleJSONBuilder
 
-    conf_builder = get_conf_builder()
+    conf_builder = get_conf_builder(srcdir)
     doctreedir = os.path.join(destdir, '.doctrees')
 
     app = Sphinx(srcdir=srcdir, confdir=srcdir, outdir=destdir,
@@ -34,8 +34,8 @@ def build(srcdir, destdir):
 
     return app.statuscode
 
-def get_conf_builder():
-    with open('conf.py') as conf_file:
+def get_conf_builder(srcdir):
+    with open(os.path.join(srcdir, 'conf.py')) as conf_file:
         conf_data = conf_file.read()
 
     try:


### PR DESCRIPTION
This was a little ambiguous as to where exactly `conf.py` should be found, resulting in ENOENT errors. This change declares that it will be directly within the source directory.