### PR TITLE
Duplicated content with the deconst-single builder

### DIFF
--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -11,6 +11,7 @@ from sphinx.builders.html import SingleFileHTMLBuilder
 from sphinx.util.osutil import relative_uri
 from sphinx.util.console import bold
 from sphinx.config import Config
+from docutils.io import StringOutput
 from deconstrst.config import Configuration
 
 # Tell Sphinx about the deconst_default_layout key.
@@ -86,10 +87,11 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         self.fix_refuris(toc)
 
         rendered_title = self.render_partial(title)['title']
-        rendered_body = self.render_partial(doctree)['fragment']
         rendered_toc = self.render_partial(toc)['fragment']
         layout_key = meta.get('deconstlayout',
                               self.config.deconst_default_layout)
+
+        rendered_body = self.write_body(doctree)
 
         envelope = {
             "title": meta.get('deconsttitle', rendered_title),
@@ -103,6 +105,15 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
 
         with open(outfile, 'w', encoding="utf-8") as dumpfile:
             json.dump(envelope, dumpfile)
+
+    def write_body(self, doctree):
+        destination = StringOutput(encoding='utf-8')
+        doctree.settings = self.docsettings
+
+        self.docwriter.write(doctree, destination)
+        self.docwriter.assemble_parts()
+
+        return self.docwriter.parts['fragment']
 
     def finish(self):
         """


### PR DESCRIPTION
For reasons unknown, `render_partial()` renders the body doctree _twice_. Source-diving into Sphinx a little reveals that the SingleFileHTMLBuilder [calls `write_doc()`](https://github.com/sphinx-doc/sphinx/blob/1.3.1/sphinx/builders/html.py#L430-L445) to convert the body doctree into HTML rather than `render_partial()`, so I ported the relevant bits from that into our builder and it seems to be working properly now.

This is the root cause of rackerlabs/nexus-control#176.

So about those preparer tests... :wink: