### PR TITLE
Base the Docker image on Alpine instead.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.4.3
+FROM alpine:3.2
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
+
+RUN apk add --update python3 && rm -rf /var/cache/apk/*
+RUN pip3 install --upgrade pip
 
 RUN mkdir -p /usr/src/app /usr/content-repo
 
 COPY . /usr/src/app
-RUN pip install /usr/src/app
+RUN pip3 install /usr/src/app
 
 VOLUME /usr/content-repo
 WORKDIR /usr/content-repo


### PR DESCRIPTION
This'll do nicely:

```bash
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
after               latest              d745ec15f28c        2 minutes ago       101.4 MB
before              latest              b5a442415a0d        8 minutes ago       735.5 MB
```