### PR TITLE
Leave absolute URLs with anchors alone.

### DIFF
--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import mimetypes
 import json
 from os import path
@@ -50,6 +51,10 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
             refuri = refnode['refuri']
             hashindex = refuri.rfind('#')
             if hashindex < 0:
+                continue
+
+            # Leave absolute URLs alone
+            if re.match("^https?://", refuri):
                 continue
 
             refnode['refuri'] = refuri[hashindex:]


### PR DESCRIPTION
This prevents the deconst preparer from changing _all_ links with anchors to anchors on the current page.

Re: deconst/deconst-docs#182