### PR TITLE
Option to disable TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ export CONTENT_STORE_URL=http://my-content-store.com:9000/
 export CONTENT_STORE_APIKEY="cd54a09f6593cb5b17177..."
 export CONTENT_ID_BASE=https://github.com/myorg/myrepo
 
+# Ignore TLS certificate verification
+# Very bad, but sometimes necessary in development or local environments
+# export CONTENT_STORE_TLS_VERIFY="false"
+
 ./deconst-preparer-sphinx.sh /path/to/control-repo
 ```
 

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -105,6 +105,7 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         auth = 'deconst apikey="{}"'.format(
             self.deconst_config.content_store_apikey)
         headers = {"Authorization": auth}
+        verify = self.deconst_config.tls_verify
 
         url = self.deconst_config.content_store_url + "assets"
         basename = path.basename(srcfile)
@@ -114,6 +115,7 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
             payload = open(srcfile, 'rb')
         files = {basename: payload}
 
-        response = requests.post(url, files=files, headers=headers)
+        response = requests.post(url, files=files, headers=headers,
+                                 verify=verify)
         response.raise_for_status()
         return response.json()[basename]

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -143,6 +143,7 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         auth = 'deconst apikey="{}"'.format(
             self.deconst_config.content_store_apikey)
         headers = {"Authorization": auth}
+        verify = self.deconst_config.tls_verify
 
         url = self.deconst_config.content_store_url + "assets"
         basename = path.basename(srcfile)
@@ -152,6 +153,7 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
             payload = open(srcfile, 'rb')
         files = {basename: payload}
 
-        response = requests.post(url, files=files, headers=headers)
+        response = requests.post(url, files=files, headers=headers,
+                                 verify=verify)
         response.raise_for_status()
         return response.json()[basename]

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -24,6 +24,7 @@ class Configuration:
         self.content_store_apikey = env.get("CONTENT_STORE_APIKEY")
         self.content_id_base = _normalize(env.get("CONTENT_ID_BASE"))
         self.is_primary = env.get("TRAVIS_PULL_REQUEST") == "false"
+        self.tls_verify = env.get("CONTENT_STORE_TLS_VERIFY") != "false"
 
     def apply_file(self, f):
         """

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -48,7 +48,8 @@ def get_conf_builder(srcdir):
 
     return locals().get('builder', DEFAULT_BUILDER)
 
-def submit(destdir, content_store_url, content_store_apikey, content_id_base):
+def submit(destdir, content_store_url, content_store_apikey, content_id_base,
+           verify):
     """
     Submit the generated json files to the content store API.
     """


### PR DESCRIPTION
It makes me sad to do this, but I don't want to drop :moneybag: on a real TLS cert for [deconst.horse](https://deconst.horse/) with letsencrypt coming out in a few short weeks. It'll be nice for quick personal instances with self-signed certs too.