### PR TITLE
Unsearchable

### DIFF
--- a/deconstrst/builders/__init__.py
+++ b/deconstrst/builders/__init__.py
@@ -1,0 +1,5 @@
+from sphinx.config import Config
+
+# Tell Sphinx about the deconst_default_layout and deconst_default_unsearchable keys.
+Config.config_values["deconst_default_layout"] = ("default", "html")
+Config.config_values["deconst_default_unsearchable"] = ("default", None)

--- a/deconstrst/builders/__init__.py
+++ b/deconstrst/builders/__init__.py
@@ -2,4 +2,4 @@ from sphinx.config import Config
 
 # Tell Sphinx about the deconst_default_layout and deconst_default_unsearchable keys.
 Config.config_values["deconst_default_layout"] = ("default", "html")
-Config.config_values["deconst_default_unsearchable"] = ("default", None)
+Config.config_values["deconst_default_unsearchable"] = (None, "html")

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -52,7 +52,8 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         }
 
         if context["deconst_unsearchable"] is not None:
-            envelope["unsearchable"] = context["deconst_unsearchable"]
+            unsearchable = context["deconst_unsearchable"] in ("true", True)
+            envelope["unsearchable"] = unsearchable
 
         n = context.get("next")
         p = context.get("prev")

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -8,11 +8,7 @@ import requests
 from docutils import nodes
 from sphinx.builders.html import JSONHTMLBuilder
 from sphinx.util import jsonimpl
-from sphinx.config import Config
 from deconstrst.config import Configuration
-
-# Tell Sphinx about the deconst_default_layout key.
-Config.config_values["deconst_default_layout"] = ("default", "html")
 
 
 class DeconstSerialJSONBuilder(JSONHTMLBuilder):
@@ -87,7 +83,8 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         ctx["deconst_layout_key"] = meta.get(
             "deconstlayout", self.config.deconst_default_layout)
         ctx["deconst_title"] = meta.get("deconsttitle", ctx["title"])
-        ctx["deconst_unsearchable"] = meta.get("deconstunsearchable")
+        ctx["deconst_unsearchable"] = meta.get(
+            "deconstunsearchable", self.config.deconst_default_unsearchable)
 
         super().handle_page(pagename, ctx, *args, **kwargs)
 

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -55,6 +55,9 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
             "layout_key": context["deconst_layout_key"]
         }
 
+        if context["deconst_unsearchable"] is not None:
+            envelope["unsearchable"] = context["deconst_unsearchable"]
+
         n = context.get("next")
         p = context.get("prev")
 
@@ -84,6 +87,7 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         ctx["deconst_layout_key"] = meta.get(
             "deconstlayout", self.config.deconst_default_layout)
         ctx["deconst_title"] = meta.get("deconsttitle", ctx["title"])
+        ctx["deconst_unsearchable"] = meta.get("deconstunsearchable")
 
         super().handle_page(pagename, ctx, *args, **kwargs)
 

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -11,12 +11,8 @@ from docutils import nodes
 from sphinx.builders.html import SingleFileHTMLBuilder
 from sphinx.util.osutil import relative_uri
 from sphinx.util.console import bold
-from sphinx.config import Config
 from docutils.io import StringOutput
 from deconstrst.config import Configuration
-
-# Tell Sphinx about the deconst_default_layout key.
-Config.config_values["deconst_default_layout"] = ("default", "html")
 
 
 class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
@@ -95,7 +91,8 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         rendered_toc = self.render_partial(toc)['fragment']
         layout_key = meta.get('deconstlayout',
                               self.config.deconst_default_layout)
-        unsearchable = meta.get('deconstunsearchable')
+        unsearchable = meta.get('deconstunsearchable',
+                                self.config.deconst_default_unsearchable)
 
         rendered_body = self.write_body(doctree)
 

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -95,6 +95,7 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         rendered_toc = self.render_partial(toc)['fragment']
         layout_key = meta.get('deconstlayout',
                               self.config.deconst_default_layout)
+        unsearchable = meta.get('deconstunsearchable')
 
         rendered_body = self.write_body(doctree)
 
@@ -105,6 +106,9 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
             "layout_key": layout_key,
             "meta": dict(meta)
         }
+
+        if unsearchable is not None:
+            envelope["unsearchable"] = unsearchable
 
         outfile = os.path.join(self.outdir, self.config.master_doc + '.json')
 

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -94,7 +94,8 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
 
         unsearchable = meta.get('deconstunsearchable',
                                 self.config.deconst_default_unsearchable)
-        unsearchable = unsearchable in ("true", True)
+        if unsearchable is not None:
+            unsearchable = unsearchable in ("true", True)
 
         rendered_body = self.write_body(doctree)
 

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -91,8 +91,10 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         rendered_toc = self.render_partial(toc)['fragment']
         layout_key = meta.get('deconstlayout',
                               self.config.deconst_default_layout)
+
         unsearchable = meta.get('deconstunsearchable',
                                 self.config.deconst_default_unsearchable)
+        unsearchable = unsearchable in ("true", True)
 
         rendered_body = self.write_body(doctree)
 


### PR DESCRIPTION
Allow content to be marked as `unsearchable`.

References deconst/content-service#63 and deconst/deconst-docs#187.