### PR TITLE
Support global and per-document categories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ Similary, you can override the `"title"` Sphinx generates for any page by specif
 ```
 
 This is especially important for your `index.rst` file, which by default generates a title of "&lt; no title &gt;".
+
+### Categories
+
+You can set the Deconst categories for each page with the `deconstcategories` per-page attribute:
+
+```rst
+:deconstcategories: category one, category two
+```
+
+Categories that should be applied to *all* pages may be specifed in your `conf.py` file, with the rest of your Sphinx settings:
+
+```python
+deconst_categories = ['global category', 'global category']
+```

--- a/deconstrst/builders/__init__.py
+++ b/deconstrst/builders/__init__.py
@@ -3,3 +3,4 @@ from sphinx.config import Config
 # Tell Sphinx about the deconst_default_layout and deconst_default_unsearchable keys.
 Config.config_values["deconst_default_layout"] = ("default", "html")
 Config.config_values["deconst_default_unsearchable"] = (None, "html")
+Config.config_values["deconst_categories"] = (None, "html")

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import mimetypes
 from os import path
 
@@ -55,6 +56,15 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
             unsearchable = context["deconst_unsearchable"] in ("true", True)
             envelope["unsearchable"] = unsearchable
 
+        page_cats = context["deconst_categories"]
+        global_cats = self.config.deconst_categories
+        if page_cats is not None or global_cats is not None:
+            cats = set()
+            if page_cats is not None:
+                cats.update(re.split("\s*,\s*", page_cats))
+            cats.update(global_cats or [])
+            envelope["categories"] = list(cats)
+
         n = context.get("next")
         p = context.get("prev")
 
@@ -84,6 +94,7 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         ctx["deconst_layout_key"] = meta.get(
             "deconstlayout", self.config.deconst_default_layout)
         ctx["deconst_title"] = meta.get("deconsttitle", ctx["title"])
+        ctx["deconst_categories"] = meta.get("deconstcategories")
         ctx["deconst_unsearchable"] = meta.get(
             "deconstunsearchable", self.config.deconst_default_unsearchable)
 

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -110,6 +110,15 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         if unsearchable is not None:
             envelope["unsearchable"] = unsearchable
 
+        page_cats = meta.get('deconstcategories')
+        global_cats = self.config.deconst_categories
+        if page_cats is not None or global_cats is not None:
+            cats = set()
+            if page_cats is not None:
+                cats.update(re.split("\s*,\s*", page_cats))
+            cats.update(global_cats or [])
+            envelope["categories"] = list(cats)
+
         outfile = os.path.join(self.outdir, self.config.master_doc + '.json')
 
         with open(outfile, 'w', encoding="utf-8") as dumpfile:


### PR DESCRIPTION
This is more important with the final work on deconst/deconst-docs#187.