### PR TITLE
Add repo-wide metadata and a Github Issues URL

### DIFF
--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -46,10 +46,15 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         envelope, instead.
         """
 
+        # Merge this page's metadata with the repo-wide data.
+        meta = self.deconst_config.meta.copy()
+        meta.update(context['meta'])
+
         envelope = {
             "body": context["body"],
             "title": context["deconst_title"],
-            "layout_key": context["deconst_layout_key"]
+            "layout_key": context["deconst_layout_key"],
+            "meta": meta
         }
 
         if context["deconst_unsearchable"] is not None:

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -80,7 +80,9 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
         if self.should_submit:
             self.post_process_images(doctree)
 
-        meta = self.env.metadata.get(self.config.master_doc)
+        # Merge this page's metadata with the repo-wide data.
+        meta = self.deconst_config.meta.copy()
+        meta.update(self.env.metadata.get(self.config.master_doc))
 
         title = self.env.longtitles.get(self.config.master_doc)
         toc = self.env.get_toctree_for(self.config.master_doc, self, False)

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -44,9 +44,17 @@ class Configuration:
                     print("Using environment variable CONTENT_ID_BASE=[{}] "
                           "instead of _deconst.json setting [{}]."
                           .format(self.content_id_base, value))
+            elif setting == "githubUrl":
+                self.github_url = value
+                self.github_issues_url = '/'.join(segment.strip('/') for segment in [value, 'issues'])
+            elif setting == "meta":
+                self.meta = value
             else:
                 print("Ignoring an unrecognized configuration setting: [{}]"
                       .format(setting))
+
+        # Add the Github issues URL to the repository-wide metadata
+        self.meta.update({'github_issues_url': self.github_issues_url})
 
     def skip_submit_reasons(self):
         """

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -25,6 +25,7 @@ class Configuration:
         self.content_id_base = _normalize(env.get("CONTENT_ID_BASE"))
         self.is_primary = env.get("TRAVIS_PULL_REQUEST") == "false"
         self.tls_verify = env.get("CONTENT_STORE_TLS_VERIFY") != "false"
+        self.meta = {}
 
     def apply_file(self, f):
         """
@@ -54,7 +55,9 @@ class Configuration:
                       .format(setting))
 
         # Add the Github issues URL to the repository-wide metadata
-        self.meta.update({'github_issues_url': self.github_issues_url})
+        if hasattr(self, 'github_issues_url'):
+            self.meta.update({'github_issues_url': self.github_issues_url})
+
 
     def skip_submit_reasons(self):
         """


### PR DESCRIPTION
Looks for a `meta` key in `_deconst.json` and adds everything in there to a matching key on each content envelope. If the individual page has also specified metadata, the two are merged, allowing individual documents to override repository-wide metadata.

Also adds a `githubUrl` key to `_deconst.json` which is used to derive a GitHub issues URL, which is added to the repository-wide metadata. This smells like vendor lock-in with GitHub, and we should perhaps just allow content owners to provide an issues URL, whether it be Github, Redmine, et al.