### PR TITLE
Optionally accept a CONTENT_ROOT.

### DIFF
--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -13,10 +13,15 @@ __version__ = '0.1.0'
 
 def main(directory=False):
 
-    if directory:
-        os.chdir(directory)
-
     config = Configuration(os.environ)
+
+    if config.content_root:
+        if directory && directory != config.content_root:
+            print("Warning: Overriding CONTENT_ROOT [{}] with argument [{}].".format(config.content_root, directory))
+        else:
+            os.chdir(config.content_root)
+    elif directory:
+        os.chdir(directory)
 
     if os.path.exists("_deconst.json"):
         with open("_deconst.json", "r", encoding="utf-8") as cf:

--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -16,7 +16,7 @@ def main(directory=False):
     config = Configuration(os.environ)
 
     if config.content_root:
-        if directory && directory != config.content_root:
+        if directory and directory != config.content_root:
             print("Warning: Overriding CONTENT_ROOT [{}] with argument [{}].".format(config.content_root, directory))
         else:
             os.chdir(config.content_root)

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -21,6 +21,7 @@ class Configuration:
     """
 
     def __init__(self, env):
+        self.content_root = env.get("CONTENT_ROOT")
         self.content_store_url = _normalize(env.get("CONTENT_STORE_URL"))
         self.content_store_apikey = env.get("CONTENT_STORE_APIKEY")
         self.content_id_base = _normalize(env.get("CONTENT_ID_BASE"))
@@ -61,7 +62,7 @@ class Configuration:
         else:
             self.github_branch = "master"
 
-    def get_git_root (self, d):
+    def get_git_root(self, d):
         """
         Walk up until we find the ".git" directory, and return its parent
         """


### PR DESCRIPTION
Accept a `CONTENT_ROOT` environment variable to prepare content from paths other than the cwd, notably `--volumes-from` mounted paths.

In service of deconst/strider-deconst-content#3.