### PR TITLE
Github Edit URLs should not be generated when no repo URL is provided

### DIFF
--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -56,7 +56,7 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         meta = self.deconst_config.meta.copy()
         meta.update(context['meta'])
 
-        if self.git_root != None and hasattr(self.deconst_config, "github_url"):
+        if self.git_root != None and self.deconst_config.github_url != "":
             # current_page_name has no extension, and it _might_ not be .rst
             fileglob = path.join(
                 os.getcwd(), context["current_page_name"] + ".*"

--- a/deconstrst/builders/single.py
+++ b/deconstrst/builders/single.py
@@ -107,7 +107,7 @@ class DeconstSingleJSONBuilder(SingleFileHTMLBuilder):
 
         rendered_body = self.write_body(doctree)
 
-        if self.git_root != None and hasattr(self.deconst_config, "github_url"):
+        if self.git_root != None and self.deconst_config.github_url != "":
             # current_page_name has no extension, and it _might_ not be .rst
             fileglob = path.join(
                 os.getcwd(), self.env.srcdir, self.config.master_doc + ".*"


### PR DESCRIPTION
I was previously checking whether the config object has the `github_url` attribute, but it always will because we assign it a default value. Checking for it to equal the default value instead.