### PR TITLE
Adhere to the new preparer protocol

### DIFF
--- a/deconstrst/__init__.py
+++ b/deconstrst/__init__.py
@@ -27,6 +27,11 @@ def main(directory=False):
         with open("_deconst.json", "r", encoding="utf-8") as cf:
             config.apply_file(cf)
 
+    if config.skip_submit_reasons():
+        # Ensure that the envelope and asset directories exist.
+        os.makedirs(config.envelope_dir, exist_ok=True)
+        os.makedirs(config.asset_dir, exist_ok=True)
+
     # Lock source and destination to the same paths as the Makefile.
     srcdir = '.'
     destdir = os.path.join('_build', get_conf_builder(srcdir))

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -121,7 +121,6 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
             content_id = path.join(self.deconst_config.content_id_base, content_id_suffix)
             if content_id.endswith('/'):
                 content_id = content_id[:-1]
-            print("content_id = {}".format(content_id))
 
             envelope_filename = urllib.parse.quote(content_id, safe='') + '.json'
             envelope_path = path.join(self.deconst_config.envelope_dir, envelope_filename)

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -15,6 +15,7 @@ from sphinx.util import jsonimpl
 from deconstrst.config import Configuration
 from .writer import OffsetHTMLTranslator
 
+
 class DeconstSerialJSONBuilder(JSONHTMLBuilder):
     """
     Custom Sphinx builder that generates Deconst-compatible JSON documents.

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -114,6 +114,9 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
         if self.should_submit:
             super().dump_context(envelope, filename)
         else:
+            # Inject asset offsets so the submitter can inject asset URLs.
+            envelope["asset_offsets"] = self.docwriter.visitor.calculate_offsets()
+
             # Write the envelope to ENVELOPE_DIR.
             dirname, basename = path.split(context['current_page_name'])
             if basename == 'index':
@@ -149,7 +152,7 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
     def post_process_images(self, doctree):
         """
         Publish images to the content store. Modify the image reference with
-        the
+        the public URL of the uploaded image.
         """
 
         JSONHTMLBuilder.post_process_images(self, doctree)

--- a/deconstrst/builders/serial.py
+++ b/deconstrst/builders/serial.py
@@ -6,13 +6,14 @@ import mimetypes
 from os import path
 import glob
 import urllib.parse
+import shutil
 
 import requests
 from docutils import nodes
 from sphinx.builders.html import JSONHTMLBuilder
 from sphinx.util import jsonimpl
 from deconstrst.config import Configuration
-
+from .writer import OffsetHTMLTranslator
 
 class DeconstSerialJSONBuilder(JSONHTMLBuilder):
     """
@@ -25,6 +26,8 @@ class DeconstSerialJSONBuilder(JSONHTMLBuilder):
 
     def init(self):
         JSONHTMLBuilder.init(self)
+
+        self.translator_class = OffsetHTMLTranslator
 
         self.deconst_config = Configuration(os.environ)
 

--- a/deconstrst/builders/writer.py
+++ b/deconstrst/builders/writer.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+import shutil
+import re
+from os import path
+
+from sphinx.writers.html import HTMLTranslator
+
+# Regexp to match the source attribute of an <img> tag that's been generated
+# with a placeholder.
+RE_SRCATTR = re.compile(r"src\s*=\s*\\\"(X)\\\"")
+
+class OffsetHTMLTranslator(HTMLTranslator):
+    """
+    Hook Sphinx's HTMLTranslator to track the offsets of image nodes within the
+    rendered content.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.asset_offsets = {}
+
+        dc = self.builder.deconst_config
+        self.should_submit = not dc.skip_submit_reasons()
+        self.asset_src_root = '_images' # This is actually hardcoded in StandaloneHTMLBuilder
+        self.asset_dest_root = dc.asset_dir
+
+        self.jsonimpl = self.builder.implementation
+
+    def visit_image(self, node):
+        """
+        Record the offset for this asset reference.
+        """
+
+        if not self.should_submit:
+            asset_src_path = node['uri']
+            asset_rel_path = path.relpath(asset_src_path, self.asset_src_root)
+            asset_dest_path = path.join(self.asset_dest_root, asset_rel_path)
+
+            shutil.copyfile(asset_src_path, asset_dest_path)
+            node['uri'] = 'X'
+
+            base_offset = self.current_body_offset()
+
+        super().visit_image(node)
+
+        if not self.should_submit:
+            chunk = self.body[-1]
+            chunk_match = RE_SRCATTR.search(self.jsonimpl.dumps(chunk))
+            if not chunk_match:
+                msg = "Unable to find image tag placeholder src attribute within [{}]".format(self.body[-1])
+                raise Exception(msg)
+
+            # Account for the starting " prepended by the jsonimpl.dumps call
+            chunk_offset = chunk_match.start() - 1
+            offset = base_offset + chunk_offset
+
+            print("asset [{}] offset = {}".format(asset_rel_path, offset))
+            self.asset_offsets[asset_rel_path] = offset
+
+    def current_body_offset(self):
+        """
+        Calculate the current character offset within "body".
+        """
+
+        # Account for preamble material.
+        # See docutils.writers.html4css1.HTMLTranslator.astext
+        content = ''.join(self.head_prefix + self.head + self.stylesheet
+            + self.body_prefix + self.body_pre_docinfo + self.docinfo
+            + self.body)
+        return len(self.jsonimpl.dumps(content)) - 2

--- a/deconstrst/config.py
+++ b/deconstrst/config.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import os
 from os import path
 
 
@@ -22,11 +23,17 @@ class Configuration:
 
     def __init__(self, env):
         self.content_root = env.get("CONTENT_ROOT")
+        self.content_id_base = _normalize(env.get("CONTENT_ID_BASE"))
+
+        self.envelope_dir = env.get("ENVELOPE_DIR", path.join(os.getcwd(), '_build', 'deconst-envelopes'))
+        self.asset_dir = env.get("ASSET_DIR", path.join(os.getcwd(), '_build', 'deconst-assets'))
+
+        # To deprecate
         self.content_store_url = _normalize(env.get("CONTENT_STORE_URL"))
         self.content_store_apikey = env.get("CONTENT_STORE_APIKEY")
-        self.content_id_base = _normalize(env.get("CONTENT_ID_BASE"))
         self.is_primary = env.get("TRAVIS_PULL_REQUEST") == "false"
         self.tls_verify = env.get("CONTENT_STORE_TLS_VERIFY") != "false"
+
         self.meta = {}
         self.github_url = ""
         self.github_branch = "master"


### PR DESCRIPTION
When not submitting content to a content store API, write metadata envelopes to `ENVELOPE_DIR` with filenames of `<content-id>.json` and copy assets to `ASSET_DIR`.

Fixes #52.