### PR TITLE
Double dot in github_edit_url.

### DIFF
--- a/deconstrst/builders/envelope.py
+++ b/deconstrst/builders/envelope.py
@@ -117,7 +117,7 @@ class Envelope:
         if self.deconst_config.git_root and self.deconst_config.github_url:
             full_path = path.join(os.getcwd(),
                                   self.builder.env.srcdir,
-                                  self.docname + '.' + self.builder.config.source_suffix[0])
+                                  self.docname + self.builder.config.source_suffix[0])
 
             edit_segments = [
                 self.deconst_config.github_url,


### PR DESCRIPTION
It turns out that the `source_suffix` already includes the leading `.`.

Fixes #65.