### PR TITLE
Add bolditalic and sphinxmark extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alabaster==0.7.7
 Babel==2.3.4
+bolditalic==0.1.0
 certifi==2016.2.28
 docutils==0.12
 imagesize==0.7.1
@@ -11,5 +12,6 @@ requests==2.10.0
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.4.1
+sphinxmark==0.1.14
 sphinx-rtd-theme==0.1.9
 termcolor==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.7
 Babel==2.3.4
-bolditalic==0.1.0
+bolditalic==0.1.2
 certifi==2016.2.28
 docutils==0.12
 imagesize==0.7.1


### PR DESCRIPTION
Add bolditalic and sphinxmark extensions to requirements.txt
to enable bolditalic styling and watermarks in Sphinx documents.

rackerlabs/docs-workstream#61
rackerlabs/docs-workstream#123