### PR TITLE
Fix for CVE-2018-18074

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 Pygments==2.1.3
 pytz==2016.4
-requests==2.10.0
+requests==2.20.0
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.4.1


### PR DESCRIPTION
Closes INFODEV-2785
Relates to https://github.com/deconst/preparer-sphinx/pull/78/